### PR TITLE
fix: fail when loading pipeline func during init

### DIFF
--- a/src/config/PipelineFactory.h
+++ b/src/config/PipelineFactory.h
@@ -86,6 +86,10 @@ public:
 
 			std::string cn = delibbed.second;
 			pipelineFunc = (T) dlsym(dlhandle, cn.c_str());
+			if (pipelineFunc == nullptr) {
+				printf("Error: %s\n", dlerror());
+				exit(1);
+			}
 
 			functionMap[delibbed.second] = pipelineFunc;
 


### PR DESCRIPTION
# Description

When loading pipeline functions from a library, if the function was not found we were not throwing any error

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules

