### PR TITLE
fix: exact match pipeline and lib name when loading

### DIFF
--- a/src/config/PipelineFactory.h
+++ b/src/config/PipelineFactory.h
@@ -62,8 +62,14 @@ public:
 	 * Loads the plugin into the program space
 	 */
 	template <class T> void loadPipeline(const std::string& pluginName, std::map<std::string, T> &functionMap) {
-		auto it = std::find_if(libNames.begin(), libNames.end(),
-							   [pluginName](const std::string &s) { return (s.find(pluginName) != std::string::npos); });
+		auto it = std::find_if(libNames.begin(), libNames.end(), [pluginName](const std::string &s) {
+			std::string pluginLibFile = s;
+			std::pair<std::string, std::string> delibbed = libnameothy(pluginLibFile);
+			// pluginName should match the library name
+			// for a lib X, the library file name will be of the form <path>/libX.<ext>
+			// 'libnameothy' strips the path, 'lib' and extension from the library path
+			return pluginName == delibbed.first;
+		});
 		if (it == libNames.end()) {
 			throw std::runtime_error("Plugin is not available : " + pluginName);
 		}


### PR DESCRIPTION
# Description

Currently, we are using a substring match. This can cause issues like invalid pipeline names which is a substring of lib name getting allowed in the config.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules

