### PR TITLE
fix: `SOURCE_HOSTNAME` null check when parsing config

### DIFF
--- a/src/config/ConfigParser.cpp
+++ b/src/config/ConfigParser.cpp
@@ -102,7 +102,7 @@ XMLError ConfigParser::LoadProxyServerConfigurations(XMLNode *pRoot, PROXY_CONFI
 							}
 
 							XMLElement *pSourceHostName = pService->FirstChildElement("SOURCE_HOSTNAME");
-							if (NULL != pHost) {
+							if (NULL != pSourceHostName) {
 								auto sourceHostname = "";
 								sourceHostname = pSourceHostName->GetText();
 								service.source_hostname = sourceHostname;


### PR DESCRIPTION
# Description

The field checked for null was different.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules

