### PR TITLE
fix: stack allocate http-response

### DIFF
--- a/src/protocol_server.h
+++ b/src/protocol_server.h
@@ -72,10 +72,10 @@ int initProtocolServers() {
                                 CommandDispatcher::Dispatch(value.auth->handler, &context);
                                 if (!std::any_cast<bool>(context.Get(AUTH_AUTHENTICATED_KEY)))
                                 {
-                                    auto *response = new simple_http_server::HttpResponse(simple_http_server::HttpStatusCode::Unauthorized);
-                                    response->SetHeader("Content-Type", "application/json");
-                                    response->SetContent("Unauthorized");
-                                    return *response;
+                                    simple_http_server::HttpResponse response(simple_http_server::HttpStatusCode::Unauthorized);
+                                    response.SetHeader("Content-Type", "application/json");
+                                    response.SetContent("Unauthorized");
+                                    return response;
                                 }
 
                                 if (route.auth.authorization != "") {
@@ -85,17 +85,17 @@ int initProtocolServers() {
                                     CommandDispatcher::Dispatch(value.auth->authorization->handler, &context);
                                     if (!std::any_cast<bool>(context.Get(AUTHORIZATION_AUTHORIZED_KEY)))
                                     {
-                                        auto *response = new simple_http_server::HttpResponse(simple_http_server::HttpStatusCode::Forbidden);
-                                        response->SetHeader("Content-Type", "application/json");
-                                        response->SetContent("Forbidden");
-                                        return *response;
+                                        simple_http_server::HttpResponse response(simple_http_server::HttpStatusCode::Forbidden);
+                                        response.SetHeader("Content-Type", "application/json");
+                                        response.SetContent("Forbidden");
+                                        return response;
                                     }
                                 }
                             }
 
                             CommandDispatcher::Dispatch(route.request_handler, &context);
-                            auto response = std::any_cast<simple_http_server::HttpResponse *>(context.Get("response"));
-                            return *response;
+                            auto response = std::any_cast<simple_http_server::HttpResponse>(context.Get("response"));
+                            return response;
                         }
                 );
             }


### PR DESCRIPTION
# Description

The execution context will have the `HttpResponse` object instead of it's pointer after [this](https://github.com/ChistaDATA/asabru-handlers/pull/47) PR is merged. This change is needed to support it. This will fix the issue where the response object is leaking.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] Any dependent changes have been merged and published in downstream modules

